### PR TITLE
fix: record class change

### DIFF
--- a/src/main/java/com/dontforget/dontforget/app/anniversary/api/request/AnniversaryCreateRequest.java
+++ b/src/main/java/com/dontforget/dontforget/app/anniversary/api/request/AnniversaryCreateRequest.java
@@ -22,6 +22,7 @@ public class AnniversaryCreateRequest {
     private CalendarType calendarType;
 
     private CardType cardType;
+
     private List<NoticeType> alarmSchedule;
 
     public AnniversaryCreateRequest(

--- a/src/main/java/com/dontforget/dontforget/app/anniversary/api/request/AnniversaryUpdateRequest.java
+++ b/src/main/java/com/dontforget/dontforget/app/anniversary/api/request/AnniversaryUpdateRequest.java
@@ -1,18 +1,44 @@
 package com.dontforget.dontforget.app.anniversary.api.request;
 
 import com.dontforget.dontforget.common.CalendarType;
+import com.dontforget.dontforget.common.CardType;
 import com.dontforget.dontforget.domain.anniversary.query.UpdateAnniversaryQuery;
 import com.dontforget.dontforget.domain.notice.NoticeType;
 import java.time.LocalDate;
 import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-public record AnniversaryUpdateRequest(String title, LocalDate date, CalendarType type,
-    List<NoticeType> alarmSchedule, String content
-) {
+@Getter
+@NoArgsConstructor
+public class AnniversaryUpdateRequest {
 
+    private String title;
+
+    private LocalDate date;
+
+    private CalendarType calendarType;
+
+    private String content;
+
+    private List<NoticeType> alarmSchedule;
+
+    public AnniversaryUpdateRequest(
+        String title,
+        LocalDate date,
+        CalendarType calendarType,
+        List<NoticeType> alarmSchedule,
+        String content
+        ) {
+        this.title = title;
+        this.date = date;
+        this.content = content;
+        this.calendarType = calendarType;
+        this.alarmSchedule = alarmSchedule;
+    }
     public UpdateAnniversaryQuery toQuery(Long anniversaryId) {
         return new UpdateAnniversaryQuery(
-            anniversaryId, title, date, type,
+            anniversaryId, title, date, calendarType,
             alarmSchedule, content
         );
     }


### PR DESCRIPTION
### update 시 record class 에서 enum 필드 매핑이 안되는 문제 발생

request 시 record 필드로 enum 을 가질 수 없음. 이유는 자바는 다중 상속을 지원하지 않는데 enum class 는 최상위타입으로 enum class 를 가지고 있고, record 는 일반 클래스를 상속받고 있어서 그렇다. 

### 관련 자료
https://stackoverflow.com/questions/65995692/why-cant-enum-and-record-be-combined